### PR TITLE
Update IP address for www.mobile-j.de

### DIFF
--- a/src/wifi/sta-mode-access-website.md
+++ b/src/wifi/sta-mode-access-website.md
@@ -269,7 +269,7 @@ Let's send an HTTP request with GET method to the website "www.mobile-j.de". Thi
 println!("Making HTTP request");
 socket.work();
 
-let remote_addr = IpAddress::v4(142, 250, 185, 115);
+let remote_addr = IpAddress::v4(192, 178, 187, 121);
 socket.open(remote_addr, 80).unwrap();
 socket
     .write(b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n")
@@ -509,7 +509,7 @@ fn http_loop(
         println!("Making HTTP request");
         socket.work();
 
-        let remote_addr = IpAddress::v4(142, 250, 185, 115);
+        let remote_addr = IpAddress::v4(192, 178, 187, 121);
         socket.open(remote_addr, 80).unwrap();
         socket
             .write(b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n")


### PR DESCRIPTION
The IP address has changed and the site is now reachable at a new address.

Thank you for putting together this book full of tutorials! It's been super helpful in learning embedded Rust. Today I followed your Wi-Fi example and noticed that the IP address is outdated. I resolved the address to confirm:

```
% dig www.mobile-j.de +short A
ghs.googlehosted.com.
192.178.187.121
```

Which can also be confirmed by trying to make the request to the old IP via `curl`:

```
% curl -v 'http://www.mobile-j.de' --http1.0 --resolve 'www.mobile-j.de:80:142.250.185.115' --connect-timeout 5
* Added www.mobile-j.de:80:142.250.185.115 to DNS cache
* Hostname www.mobile-j.de was found in DNS cache
*   Trying 142.250.185.115:80...
* Connection timed out after 5002 milliseconds
* closing connection #0
curl: (28) Connection timed out after 5002 milliseconds
```